### PR TITLE
build(github-actions) increase the phpunit version to fix the error

### DIFF
--- a/.github/workflows/accounts-qc-php.yml
+++ b/.github/workflows/accounts-qc-php.yml
@@ -88,7 +88,4 @@ jobs:
       run: composer install
 
     - name: PHPUnit tests
-      uses: php-actions/phpunit@v5
-      with:
-        configuration: ./phpunit.xml
-        bootstrap: ./tests/bootstrap.php
+      run: composer test

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
     "prestashop/php-dev-tools": "3.*",
     "friendsofphp/php-cs-fixer": "^2.16",
     "fzaninotto/faker": "^1.9"
-  }
+  },
+  "scripts": {
+        "test": "./vendor/phpunit/phpunit/phpunit --configuration './phpunit.xml' --bootstrap './tests/bootstrap.php' --test-suffix 'Test.php,.phpt'"
+    }
 }


### PR DESCRIPTION
```
Fatal error: Uncaught Error: Call to undefined function each() in /tmp/vendor/phpunit/phpunit/src/Util/Getopt.php:38
Stack trace:
0 /tmp/vendor/phpunit/phpunit/src/TextUI/Command.php(245): PHPUnit_Util_Getopt::getopt(Array, 'd:c:hv', Array)
1 /tmp/vendor/phpunit/phpunit/src/TextUI/Command.php(120): PHPUnit_TextUI_Command->handleArguments(Array)
2 /tmp/vendor/phpunit/phpunit/src/TextUI/Command.php(109): PHPUnit_TextUI_Command->run(Array, true)
3 /tmp/vendor/phpunit/phpunit/phpunit(47): PHPUnit_TextUI_Command::main()
4 {main}
  thrown in /tmp/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38
```